### PR TITLE
Rename O1Preview variant to O1 in copilot chat

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "cargo build"
+  }
+}

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -35,7 +35,7 @@ pub enum Model {
     #[serde(alias = "gpt-3.5-turbo", rename = "gpt-3.5-turbo")]
     Gpt3_5Turbo,
     #[serde(alias = "o1-preview", rename = "o1")]
-    O1Preview,
+    O1,
     #[serde(alias = "o1-mini", rename = "o1-mini")]
     O1Mini,
     #[serde(alias = "claude-3-5-sonnet", rename = "claude-3.5-sonnet")]
@@ -46,7 +46,7 @@ impl Model {
     pub fn uses_streaming(&self) -> bool {
         match self {
             Self::Gpt4o | Self::Gpt4 | Self::Gpt3_5Turbo | Self::Claude3_5Sonnet => true,
-            Self::O1Mini | Self::O1Preview => false,
+            Self::O1Mini | Self::O1 => false,
         }
     }
 
@@ -55,7 +55,7 @@ impl Model {
             "gpt-4o" => Ok(Self::Gpt4o),
             "gpt-4" => Ok(Self::Gpt4),
             "gpt-3.5-turbo" => Ok(Self::Gpt3_5Turbo),
-            "o1-preview" => Ok(Self::O1Preview),
+            "o1" => Ok(Self::O1),
             "o1-mini" => Ok(Self::O1Mini),
             "claude-3-5-sonnet" => Ok(Self::Claude3_5Sonnet),
             _ => Err(anyhow!("Invalid model id: {}", id)),
@@ -68,7 +68,7 @@ impl Model {
             Self::Gpt4 => "gpt-4",
             Self::Gpt4o => "gpt-4o",
             Self::O1Mini => "o1-mini",
-            Self::O1Preview => "o1-preview",
+            Self::O1 => "o1",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet",
         }
     }
@@ -79,7 +79,7 @@ impl Model {
             Self::Gpt4 => "GPT-4",
             Self::Gpt4o => "GPT-4o",
             Self::O1Mini => "o1-mini",
-            Self::O1Preview => "o1-preview",
+            Self::O1 => "o1",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
         }
     }
@@ -90,7 +90,7 @@ impl Model {
             Self::Gpt4 => 32768,
             Self::Gpt3_5Turbo => 12288,
             Self::O1Mini => 20000,
-            Self::O1Preview => 20000,
+            Self::O1 => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }
     }


### PR DESCRIPTION
Rename the `O1Preview` variant to `O1` in the `Model` enum and update related functions in `crates/copilot/src/copilot_chat.rs`.

* Change the `Model` enum to rename the `O1Preview` variant to `O1`.
* Update the `from_id` function to map the string "o1" to the `O1` variant.
* Update the `id` function to return "o1" for the `O1` variant.
* Update the `display_name` function to return "o1" for the `O1` variant.
* Update the `max_token_count` function to return 20000 for the `O1` variant.

