### PR TITLE
Update copilot model to o3-mini

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -36,8 +36,8 @@ pub enum Model {
     Gpt3_5Turbo,
     #[serde(alias = "o1", rename = "o1")]
     O1,
-    #[serde(alias = "o1-mini", rename = "o1-mini")]
-    O1Mini,
+    #[serde(alias = "o3-mini", rename = "o3-mini")]
+    O3Mini,
     #[serde(alias = "claude-3-5-sonnet", rename = "claude-3.5-sonnet")]
     Claude3_5Sonnet,
 }
@@ -46,7 +46,7 @@ impl Model {
     pub fn uses_streaming(&self) -> bool {
         match self {
             Self::Gpt4o | Self::Gpt4 | Self::Gpt3_5Turbo | Self::Claude3_5Sonnet => true,
-            Self::O1Mini | Self::O1 => false,
+            Self::O3Mini | Self::O1 => false,
         }
     }
 
@@ -56,7 +56,7 @@ impl Model {
             "gpt-4" => Ok(Self::Gpt4),
             "gpt-3.5-turbo" => Ok(Self::Gpt3_5Turbo),
             "o1" => Ok(Self::O1),
-            "o1-mini" => Ok(Self::O1Mini),
+            "o3-mini" => Ok(Self::O3Mini),
             "claude-3-5-sonnet" => Ok(Self::Claude3_5Sonnet),
             _ => Err(anyhow!("Invalid model id: {}", id)),
         }
@@ -67,7 +67,7 @@ impl Model {
             Self::Gpt3_5Turbo => "gpt-3.5-turbo",
             Self::Gpt4 => "gpt-4",
             Self::Gpt4o => "gpt-4o",
-            Self::O1Mini => "o1-mini",
+            Self::O3Mini => "o3-mini",
             Self::O1 => "o1",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet",
         }
@@ -78,7 +78,7 @@ impl Model {
             Self::Gpt3_5Turbo => "GPT-3.5",
             Self::Gpt4 => "GPT-4",
             Self::Gpt4o => "GPT-4o",
-            Self::O1Mini => "o1-mini",
+            Self::O3Mini => "o3-mini",
             Self::O1 => "o1",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
         }
@@ -89,7 +89,7 @@ impl Model {
             Self::Gpt4o => 64000,
             Self::Gpt4 => 32768,
             Self::Gpt3_5Turbo => 12288,
-            Self::O1Mini => 20000,
+            Self::O3Mini => 20000,
             Self::O1 => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }


### PR DESCRIPTION
Update the `o1-mini` model to `o3-mini` in `crates/copilot/src/copilot_chat.rs`.

* **Model Enum**: Replace `O1Mini` with `O3Mini`.
* **Model::from_id Function**: Handle `o3-mini` instead of `o1-mini`.
* **Model::id Function**: Return `o3-mini` instead of `o1-mini`.
* **Model::display_name Function**: Return `o3-mini` instead of `o1-mini`.
* **Model::max_token_count Function**: Handle `O3Mini` instead of `O1Mini`.

