### PR TITLE
Fix variant O1Mini to O3Mini in enums and match statements

### DIFF
--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -79,7 +79,7 @@ impl CloudModel {
                 | open_ai::Model::FourTurbo
                 | open_ai::Model::FourOmni
                 | open_ai::Model::FourOmniMini
-                | open_ai::Model::O1Mini
+                | open_ai::Model::O3Mini
                 | open_ai::Model::O1Preview
                 | open_ai::Model::O1
                 | open_ai::Model::O3Mini

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -179,7 +179,7 @@ impl LanguageModel for CopilotChatLanguageModel {
                     CopilotChatModel::Gpt4o => open_ai::Model::FourOmni,
                     CopilotChatModel::Gpt4 => open_ai::Model::Four,
                     CopilotChatModel::Gpt3_5Turbo => open_ai::Model::ThreePointFiveTurbo,
-                    CopilotChatModel::O1 | CopilotChatModel::O1Mini => open_ai::Model::Four,
+                    CopilotChatModel::O1 | CopilotChatModel::O3Mini => open_ai::Model::Four,
                     CopilotChatModel::Claude3_5Sonnet => unreachable!(),
                 };
                 count_open_ai_tokens(request, model, cx)

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -76,8 +76,6 @@ pub enum Model {
     O1,
     #[serde(rename = "o1-preview", alias = "o1-preview")]
     O1Preview,
-    #[serde(rename = "o1-mini", alias = "o1-mini")]
-    O1Mini,
     #[serde(rename = "o3-mini", alias = "o3-mini")]
     O3Mini,
 
@@ -102,7 +100,7 @@ impl Model {
             "gpt-4o-mini" => Ok(Self::FourOmniMini),
             "o1" => Ok(Self::O1),
             "o1-preview" => Ok(Self::O1Preview),
-            "o1-mini" => Ok(Self::O1Mini),
+            "o3-mini" => Ok(Self::O3Mini),
             _ => Err(anyhow!("invalid model id")),
         }
     }
@@ -116,7 +114,6 @@ impl Model {
             Self::FourOmniMini => "gpt-4o-mini",
             Self::O1 => "o1",
             Self::O1Preview => "o1-preview",
-            Self::O1Mini => "o1-mini",
             Self::O3Mini => "o3-mini",
             Self::Custom { name, .. } => name,
         }
@@ -131,7 +128,6 @@ impl Model {
             Self::FourOmniMini => "gpt-4o-mini",
             Self::O1 => "o1",
             Self::O1Preview => "o1-preview",
-            Self::O1Mini => "o1-mini",
             Self::O3Mini => "o3-mini",
             Self::Custom {
                 name, display_name, ..
@@ -148,7 +144,6 @@ impl Model {
             Self::FourOmniMini => 128000,
             Self::O1 => 200000,
             Self::O1Preview => 128000,
-            Self::O1Mini => 128000,
             Self::O3Mini => 200000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }


### PR DESCRIPTION
Replace the variant `O1Mini` with `O3Mini` in the code.

* **crates/language_model/src/model/cloud_model.rs**
  - Replace `O1Mini` with `O3Mini` in the `CloudModel` enum.

* **crates/language_models/src/provider/copilot_chat.rs**
  - Replace `O1Mini` with `O3Mini` in the match statement.

* **crates/open_ai/src/open_ai.rs**
  - Replace `O1Mini` with `O3Mini` in the `Model` enum.
  - Update match statements to use `O3Mini` instead of `O1Mini`.

